### PR TITLE
chore: update backend test workflow to ignore main branch

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -2,6 +2,8 @@ name: Backend Tests
 
 on:
   push:
+    branches-ignore:
+      - 'main'
     paths:
       - 'backend/**'
       - '.github/workflows/backend-test.yml'


### PR DESCRIPTION
- Modified the GitHub Actions workflow to ignore pushes to the 'main' branch, ensuring that backend tests only run for other branches.
- This change helps to streamline the CI process by preventing unnecessary test runs on the main branch.
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Chore: GitHub Actionsのワークフローが更新され、'main'ブランチへのプッシュを無視するようになりました。これにより、CIプロセスが最適化され、メインブランチでの不要なテスト実行が回避されます。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->